### PR TITLE
Update to ruby 3.1; omniauth 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,20 @@
-FROM ruby:2.7.2
+FROM ruby:3.1
 ARG UNAME=app
 ARG UID=1000
 ARG GID=1000
 
 LABEL maintainer="mrio@umich.edu"
 
-RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  apt-transport-https
-
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-
-RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  nodejs \
-  vim
-
-RUN gem install bundler:2.1.4
-
+RUN gem install bundler
 
 RUN groupadd -g ${GID} -o ${UNAME}
 RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash ${UNAME}
 RUN mkdir -p /gems && chown ${UID}:${GID} /gems
 
-
-COPY --chown=${UID}:${GID} Gemfile* /app/
 USER $UNAME
 
 ENV BUNDLE_PATH /gems
 
-#Actually a secret
-ENV WEBLOGIN_SECRET 'weblogin_secret'
-ENV WEBLOGIN_ID 'weblogin_id'
-ENV RACK_COOKIE_SECRET 'rack_cookie_secret'
-
 WORKDIR /app
-RUN bundle install
-
-COPY --chown=${UID}:${GID} . /app
 
 CMD ["bundle", "exec", "ruby", "oidc_demo.rb", "-o", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-ruby '2.7.2'
-
 gem 'sinatra'
 gem 'omniauth'
 gem 'omniauth_openid_connect'
 gem 'byebug'
+gem 'net-smtp'
+gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,24 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3.2)
-      activesupport (= 6.1.3.2)
-    activesupport (6.1.3.2)
+    activemodel (7.0.2.4)
+      activesupport (= 7.0.2.4)
+    activesupport (7.0.2.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
     attr_required (1.0.1)
     bindata (2.4.10)
     byebug (11.1.3)
-    concurrent-ruby (1.1.9)
-    hashie (4.1.0)
+    concurrent-ruby (1.1.10)
+    digest (3.1.0)
+    hashie (5.0.0)
     httpclient (2.8.3)
-    i18n (1.8.10)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
@@ -26,18 +26,26 @@ GEM
       bindata
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mini_mime (1.1.0)
-    minitest (5.14.4)
+    mini_mime (1.1.2)
+    minitest (5.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    omniauth (1.9.1)
+    net-protocol (0.1.3)
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
+    nio4r (2.5.8)
+    omniauth (2.1.0)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
-    omniauth_openid_connect (0.3.5)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth_openid_connect (0.4.0)
       addressable (~> 2.5)
-      omniauth (~> 1.9)
+      omniauth (>= 1.9, < 3)
       openid_connect (~> 1.1)
-    openid_connect (1.2.0)
+    openid_connect (1.3.0)
       activemodel
       attr_required (>= 1.0.0)
       json-jwt (>= 1.5.0)
@@ -47,27 +55,30 @@ GEM
       validate_email
       validate_url
       webfinger (>= 1.0.1)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
+    puma (5.6.4)
+      nio4r (~> 2.0)
     rack (2.2.3)
-    rack-oauth2 (1.17.0)
+    rack-oauth2 (1.19.0)
       activesupport
       attr_required
       httpclient
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
-    rack-protection (2.1.0)
+    rack-protection (2.2.0)
       rack
-    ruby2_keywords (0.0.4)
-    sinatra (2.1.0)
+    ruby2_keywords (0.0.5)
+    sinatra (2.2.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
-      rack-protection (= 2.1.0)
+      rack-protection (= 2.2.0)
       tilt (~> 2.0)
-    swd (1.2.0)
+    swd (1.3.0)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
       httpclient (>= 2.4)
     tilt (2.0.10)
+    timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     validate_email (0.1.6)
@@ -76,22 +87,20 @@ GEM
     validate_url (1.0.13)
       activemodel (>= 3.0.0)
       public_suffix
-    webfinger (1.1.0)
+    webfinger (1.2.0)
       activesupport
       httpclient (>= 2.4)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
+  net-smtp
   omniauth
   omniauth_openid_connect
+  puma
   sinatra
 
-RUBY VERSION
-   ruby 2.7.2p137
-
 BUNDLED WITH
-   2.1.4
+   2.3.10

--- a/README.md
+++ b/README.md
@@ -1,17 +1,25 @@
 # oidc_omniauth_demo
 
-This is a demo of how to do authentication with weblogin using OpenID connect with omniauth.
+This is a demo of how to do authentication with OpenID Connect with omniauth.
+It has been tested with the Library OpenID Connect proxy to University of
+Michigan weblogin (weblogin.lib.umich.edu), but it should work with any OpenID
+Connect provider.
 
 ## To build
 1) Clone the repository
 2) create a .env file with the following values
 ```
-WEBLOGIN_SECRET='get-this-from-A-&-E'
-WEBLOGIN_ID='also-get-this-from-A-&-E'
+OIDC_ISSUER=
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
 ```
+
+For authentication in the Library, get these from A&E.
+
 3) build the image
 ```
 docker-compose build
+docker-compose run web bundle install
 ```
 
 4) start the site

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - .:/app
       - gem_cache:/gems
     environment:
-      - RACK_COOKIE_SECRET='rack_cookie_secret'
+      - RACK_SESSION_SECRET='rack_cookie_secret'
     env_file:
       - .env
 


### PR DESCRIPTION
- Add redirect to /login which submits a POST request to
/auth/omniauth_connect - addresses CSRF login issue (see
https://github.com/omniauth/omniauth/releases/tag/v2.0.0)

- Make environment variables more generic

- Update other dependencies including activesupport

- Update README