### PR TITLE
Update dependencies, secret to fix OpenSSL error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,95 +1,111 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.2.4)
-      activesupport (= 7.0.2.4)
-    activesupport (7.0.2.4)
+    activemodel (7.0.6)
+      activesupport (= 7.0.6)
+    activesupport (7.0.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
     attr_required (1.0.1)
-    bindata (2.4.10)
+    bindata (2.4.15)
     byebug (11.1.3)
-    concurrent-ruby (1.1.10)
-    digest (3.1.0)
+    concurrent-ruby (1.2.2)
+    date (3.3.3)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.0.2)
     hashie (5.0.0)
-    httpclient (2.8.3)
-    i18n (1.10.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json-jwt (1.13.0)
+    json-jwt (1.16.3)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
-    mail (2.7.1)
+      faraday (~> 2.0)
+      faraday-follow_redirects
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     mini_mime (1.1.2)
-    minitest (5.15.0)
-    mustermann (1.1.1)
+    minitest (5.19.0)
+    mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    net-protocol (0.1.3)
-      timeout
-    net-smtp (0.3.1)
-      digest
+    net-imap (0.3.7)
+      date
       net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
       timeout
-    nio4r (2.5.8)
-    omniauth (2.1.0)
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.9)
+    omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
-    omniauth_openid_connect (0.4.0)
-      addressable (~> 2.5)
+    omniauth_openid_connect (0.7.1)
       omniauth (>= 1.9, < 3)
-      openid_connect (~> 1.1)
-    openid_connect (1.3.0)
+      openid_connect (~> 2.2)
+    openid_connect (2.2.0)
       activemodel
       attr_required (>= 1.0.0)
-      json-jwt (>= 1.5.0)
-      rack-oauth2 (>= 1.6.1)
-      swd (>= 1.0.0)
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      net-smtp
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
       tzinfo
       validate_email
       validate_url
-      webfinger (>= 1.0.1)
-    public_suffix (4.0.7)
-    puma (5.6.4)
+      webfinger (~> 2.0)
+    public_suffix (5.0.3)
+    puma (6.3.0)
       nio4r (~> 2.0)
-    rack (2.2.3)
-    rack-oauth2 (1.19.0)
+    rack (2.2.8)
+    rack-oauth2 (2.2.0)
       activesupport
       attr_required
-      httpclient
+      faraday (~> 2.0)
+      faraday-follow_redirects
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
-    rack-protection (2.2.0)
+    rack-protection (3.0.6)
       rack
     ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
+    sinatra (3.0.6)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.0.6)
       tilt (~> 2.0)
-    swd (1.3.0)
+    swd (2.0.2)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
-      httpclient (>= 2.4)
-    tilt (2.0.10)
-    timeout (0.2.0)
-    tzinfo (2.0.4)
+      faraday (~> 2.0)
+      faraday-follow_redirects
+    tilt (2.2.0)
+    timeout (0.4.0)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
-    validate_url (1.0.13)
+    validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
-    webfinger (1.2.0)
+    webfinger (2.1.2)
       activesupport
-      httpclient (>= 2.4)
+      faraday (~> 2.0)
+      faraday-follow_redirects
 
 PLATFORMS
   ruby

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - .:/app
       - gem_cache:/gems
     environment:
-      - RACK_SESSION_SECRET='rack_cookie_secret'
+      - RACK_SESSION_SECRET='really_really_really_really_really_really_long_rack_cookie_secret'
     env_file:
       - .env
 


### PR DESCRIPTION
This PR updates the dependency versions and the length of the sample `RACK_SESSION_SECRET` in `docker-compose.yml` to get past the following error, which occurred after entering WebLogin credentials.

<img width="660" alt="Screenshot 2023-08-03 at 9 32 46 AM" src="https://github.com/mlibrary/oidc_omniauth_demo/assets/35741256/e3edc682-6c9b-4025-8b0d-52fd572ba093">


Dependencies were updated using `docker compose run web bundle update`. I'm not entirely sure if that disrupted anything else but it fixed this problem.